### PR TITLE
Reinstate Travis file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: php
+
+sudo: false
+
+php:
+  - 7.0
+  - 5.6
+
+before_install:
+    - echo "memory_limit=2048M" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+    - phpenv config-rm xdebug.ini || true
+
+install:
+    - composer install --no-interaction --prefer-source
+
+script:
+    - bin/phpspec run -fpretty --verbose


### PR DESCRIPTION
Takes the `.travis.yml` file previously in this repository, but tests against a minimum of PHP 5.6.
